### PR TITLE
[CRIB-38] updates map styles according to mapbox account migration

### DIFF
--- a/client/src/components/map/index.tsx
+++ b/client/src/components/map/index.tsx
@@ -68,7 +68,7 @@ const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
       ref={mapRef}
       mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
       style={style}
-      mapStyle="mapbox://styles/crib2025/cmc9e61rp00a601sh2jgretdw"
+      mapStyle="mapbox://styles/a-irvine/cmf43ty13003l01qscdneh6wp"
       projection="mercator"
       maxBounds={MAX_BOUNDS}
       initialViewState={{


### PR DESCRIPTION
This pull request makes a single update to the map component's configuration. The change updates the Mapbox style used for rendering the map.

* Changed the value of the `mapStyle` prop in the `Map` component to use a different Mapbox style URL (`mapbox://styles/a-irvine/cmf43ty13003l01qscdneh6wp`).