### PR TITLE
chore(client): pin nitro compatibilityDate

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -11,10 +11,14 @@ export default defineConfig({
       "@": path.resolve(import.meta.dirname, "src"),
     },
   },
+  build: {
+    // calibrated to mapbox-gl (~1.5 MB), a monolithic non-tree-shakeable chunk
+    chunkSizeWarningLimit: 1600,
+  },
   plugins: [
     tailwindcss(),
     tanstackStart(),
-    nitroV2Plugin(),
+    nitroV2Plugin({ compatibilityDate: "2026-07-09" }),
     // react's vite plugin must come after start's vite plugin
     viteReact(),
   ],

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -11,10 +11,6 @@ export default defineConfig({
       "@": path.resolve(import.meta.dirname, "src"),
     },
   },
-  build: {
-    // calibrated to mapbox-gl (~1.5 MB), a monolithic non-tree-shakeable chunk
-    chunkSizeWarningLimit: 1600,
-  },
   plugins: [
     tailwindcss(),
     tanstackStart(),


### PR DESCRIPTION
## Summary

- **Nitro `compatibilityDate` warning**: pinned to `2026-07-09` via the `nitroV2Plugin` config. Nitro was falling back to `2024-04-03`; the date snapshot controls preset behavior (e.g. Vercel function defaults), so pinning it makes builds stable across nitropack updates.

## Test plan

- [x] `pnpm build` — Nitro logs `compatibility date: 2026-07-09`, no Nitro warning