### PR TITLE
fix(quality): resolve docker:S7031 in client/Dockerfile

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -22,8 +22,8 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 tanstack
+RUN addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 tanstack
 
 COPY --from=builder --chown=tanstack:nodejs /app/.output ./.output
 


### PR DESCRIPTION
## Summary
- Merges the two consecutive `RUN` instructions (`addgroup` / `adduser`) in the `runner` stage of `client/Dockerfile` into a single instruction, so they produce one image layer instead of two.
- Resolves SonarCloud issue [AZ9CXetRrjwDjn2QRwIo](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=Vizzuality_climate_risk_index_for_biodiversity&open=AZ9CXetRrjwDjn2QRwIo) (`docker:S7031`, MINOR).

## Test plan
- [x] SonarQube MCP re-analysis of the updated Dockerfile reports 0 issues (verified locally).
- [x] `docker build client/` still succeeds — the merged command is behaviorally identical.
- [ ] SonarCloud closes the issue on the next analysis of `main` after merge.