### PR TITLE
fix(quality): resolve typescript:S2137 Map shadowing in client map component

### DIFF
--- a/client/src/components/map/index.tsx
+++ b/client/src/components/map/index.tsx
@@ -18,7 +18,7 @@ const MAX_BOUNDS: LngLatBoundsLike = [
   -224.17459662506633, 30.196000914813084, -16.362485879322406, 75.22947015173992,
 ];
 
-const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
+export const MapView: React.FC<React.PropsWithChildren> = ({ children }) => {
   const mapRef = useRef<MapRef>(null);
   const navigate = useNavigate();
   const params = useParams({ strict: false });
@@ -103,5 +103,3 @@ const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
     </ReactMapGL>
   );
 };
-
-export default Map;

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -18,7 +18,7 @@ import { Sidebar, SidebarContent, SidebarProvider } from "@/components/ui/sideba
 import { QueryProvider } from "@/providers/react-query";
 import { MapProvider } from "@/providers/map";
 import Navigation from "@/components/navigation";
-import MapView from "@/components/map";
+import { MapView } from "@/components/map";
 import ScenarioToggle from "@/components/scenario-toggle";
 import LayerManager from "@/containers/map/layer-manager";
 


### PR DESCRIPTION
## Summary
- Fixes SonarCloud issue [AZ9CXetHrjwDjn2QRwIn](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=Vizzuality_climate_risk_index_for_biodiversity&open=AZ9CXetHrjwDjn2QRwIn) — `typescript:S2137` (MAJOR): the map component variable was named `Map`, shadowing the global `Map` constructor.
- Renames the component to `MapView`, the name its only consumer (`src/routes/__root.tsx`) already imported it as.
- Converts it to a named export per the project convention of named exports for new/edited code.

## Test plan
- [x] `pnpm lint` passes (only pre-existing warning in `climate-risk-chart/chart.tsx` remains)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (5/5)
- [x] SonarCloud analysis on this PR no longer reports S2137 in `client/src/components/map/index.tsx`