### PR TITLE
fix(quality): resolve typescript:S3863 duplicate imports in client map component

### DIFF
--- a/client/src/components/map/index.tsx
+++ b/client/src/components/map/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import ReactMapGL from "react-map-gl/mapbox";
+import ReactMapGL, { Popup } from "react-map-gl/mapbox";
 
 import type { MapRef } from "react-map-gl/mapbox";
 
@@ -10,7 +10,6 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { useAreas } from "@/hooks/use-areas";
 import { useAtom } from "jotai";
 import { popupAtom } from "@/store";
-import { Popup } from "react-map-gl/mapbox";
 
 const style = { width: "100%", height: "100%" };
 


### PR DESCRIPTION
## Summary
- Fixes SonarCloud issues [AZ9CXetHrjwDjn2QRwIm](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=Vizzuality_climate_risk_index_for_biodiversity&open=AZ9CXetHrjwDjn2QRwIm) and [AZ9CXetHrjwDjn2QRwIl](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=Vizzuality_climate_risk_index_for_biodiversity&open=AZ9CXetHrjwDjn2QRwIl) — `typescript:S3863` (MINOR): `react-map-gl/mapbox` was imported multiple times in `client/src/components/map/index.tsx`.
- Merges the standalone `Popup` import into the existing value import; the `import type { MapRef }` line stays as a separate type-only import.

## Test plan
- [x] `pnpm lint` passes (only pre-existing warning in `climate-risk-chart/chart.tsx` remains)
- [x] `pnpm typecheck` passes
- [ ] SonarCloud analysis on this PR no longer reports S3863 in `client/src/components/map/index.tsx`

Related: #21 fixes `typescript:S2137` in the same file.