### PR TITLE
fix(quality): resolve remaining SonarCloud client issues (S6749, S6759)

### DIFF
--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -236,24 +236,22 @@ function Sidebar({
           data-slot="sidebar-inner"
           className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
         >
-          <>
-            {children}
+          {children}
 
-            <Button
-              type="button"
-              variant="ghost"
-              className="absolute cursor-pointer right-0 bottom-8 h-10 w-6 translate-x-full rounded-l-none rounded-r-lg border-l-0 transition-transform group-data-[collapsible=offcanvas]:translate-x-full bg-slate-200 "
-              onClick={() => setOpen(!open)}
-            >
-              <span className="sr-only">Toggle sidebar</span>
-              <div className="relative">
-                <ChevronsLeft
-                  className="group-data-[collapsible=offcanvas]:rotate-180 text-black"
-                  aria-hidden
-                />
-              </div>
-            </Button>
-          </>
+          <Button
+            type="button"
+            variant="ghost"
+            className="absolute cursor-pointer right-0 bottom-8 h-10 w-6 translate-x-full rounded-l-none rounded-r-lg border-l-0 transition-transform group-data-[collapsible=offcanvas]:translate-x-full bg-slate-200 "
+            onClick={() => setOpen(!open)}
+          >
+            <span className="sr-only">Toggle sidebar</span>
+            <div className="relative">
+              <ChevronsLeft
+                className="group-data-[collapsible=offcanvas]:rotate-180 text-black"
+                aria-hidden
+              />
+            </div>
+          </Button>
         </div>
       </div>
     </div>

--- a/client/src/containers/detail/stats/index.tsx
+++ b/client/src/containers/detail/stats/index.tsx
@@ -21,11 +21,9 @@ export default function AreaStats() {
         <span className="flex-1 uppercase font-semibold text-xs">DFO site</span>
         <span className="flex flex-1">
           {area?.website_url ? (
-            <>
-              <a href={area?.website_url} target="_blank" rel="noopener noreferrer">
-                {area.website_url}
-              </a>
-            </>
+            <a href={area?.website_url} target="_blank" rel="noopener noreferrer">
+              {area.website_url}
+            </a>
           ) : (
             "N/A"
           )}

--- a/client/src/containers/main/table/risk-index-chart/index.tsx
+++ b/client/src/containers/main/table/risk-index-chart/index.tsx
@@ -8,7 +8,7 @@ const formatter = new Intl.NumberFormat("en-US", {
 export default function RiskIndexChart({
   range,
   values,
-}: {
+}: Readonly<{
   range: {
     min: number;
     max: number;
@@ -18,7 +18,7 @@ export default function RiskIndexChart({
     max: number;
     mean: number;
   };
-}) {
+}>) {
   return (
     <div className="h-full flex items-center justify-center">
       <div className="h-[1px] bg-slate-300 w-full relative">


### PR DESCRIPTION
## Summary
- Fixes the three remaining open SonarCloud code fixes in `client/`:
  - `typescript:S6749` (MINOR) — removes a redundant fragment around a single anchor in `src/containers/detail/stats/index.tsx` ([AZ9CXerorjwDjn2QRwIg](https://sonarcloud.io/project/issues?id=Vizzuality_climate_risk_index_for_biodiversity&open=AZ9CXerorjwDjn2QRwIg)).
  - `typescript:S6749` (MINOR) — unwraps a useless fragment passed as the only child of a div in `src/components/ui/sidebar.tsx` ([AZ9CXes7rjwDjn2QRwIj](https://sonarcloud.io/project/issues?id=Vizzuality_climate_risk_index_for_biodiversity&open=AZ9CXes7rjwDjn2QRwIj)).
  - `typescript:S6759` (MINOR) — marks `RiskIndexChart` props as `Readonly<>` in `src/containers/main/table/risk-index-chart/index.tsx` ([AZ9CXepBrjwDjn2QRwIf](https://sonarcloud.io/project/issues?id=Vizzuality_climate_risk_index_for_biodiversity&open=AZ9CXepBrjwDjn2QRwIf)).
- The fourth client issue, `typescript:S2245` (Math.random() in shadcn's `SidebarMenuSkeleton`), was marked **Accepted** in SonarCloud — the value only styles a loading-skeleton width, not a security context.

## Test plan
- [x] `pnpm lint` passes (only pre-existing warning in `climate-risk-chart/chart.tsx` remains)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (5/5)
- [x] SonarCloud analysis on this PR reports no new issues; the three issue keys above close after merge