### PR TITLE
chore(quality): set sonar.python.version to 3.14

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
 sonar.exclusions=client/src/routeTree.gen.ts
+sonar.python.version=3.14


### PR DESCRIPTION
## Summary
- Resolves the SonarCloud analysis warning "Your code is analyzed as compatible with all Python 3 versions by default" by setting `sonar.python.version=3.14` in `.sonarcloud.properties`, giving the Python analyzer a precise target version.
- 3.14 is within the `requires-python = ">=3.12"` range declared in `data-processing/pyproject.toml`.

Note: the same warning dialog also mentions file-encoding problems in the source code — that one is not addressed here (needs the scanner logs to locate the offending files; `sonar.sourceEncoding=UTF-8` may be the follow-up).

## Test plan
- [ ] SonarCloud analysis on this PR completes without the Python-version warning
- [ ] Issue detection still works (analysis reports a result on the PR)