### PR TITLE
chore(quality): exclude client/public from SonarCloud analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,2 @@
-sonar.exclusions=client/src/routeTree.gen.ts
+sonar.exclusions=client/src/routeTree.gen.ts,client/public/**
 sonar.python.version=3.14


### PR DESCRIPTION
## Summary
- Resolves the second SonarCloud analysis warning — "There are problems with file encoding in the source code" — by adding `client/public/**` to `sonar.exclusions`.
- Root cause: `client/public/favicon.ico` is the only file in the repo that isn't valid UTF-8 (verified by decoding every tracked file). The scanner indexes `public/` as source, fails to read the binary as text, and logs the encoding warning. `sonar.sourceEncoding` wouldn't help since the file isn't text in any encoding.
- Excluding the whole `public/` directory (static assets + the ~4 MB pipeline-generated `wdpa.json`) rather than just the favicon means future assets dropped there can't reintroduce the warning, and the scanner skips a large data file it has no reason to analyze.

## Test plan
- [x] SonarCloud analysis on this PR completes successfully
- [ ] After merge, the "file encoding" warning no longer appears on the next main-branch analysis